### PR TITLE
Removes Spek in favor of JUnit.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ sourceSets.test.resources.srcDirs = []
 repositories {
 	mavenCentral()
 	jcenter()
-	maven { url('http://repository.jetbrains.com/all') }
 	maven { url('https://dl.bintray.com/zoltu/maven/') }
 }
 
@@ -29,5 +28,5 @@ dependencies {
 	compile(group: 'org.apache.kafka', name: 'kafka-clients', version: '0.9.0.0')
 
 	testCompile(group: 'junit', name: 'junit', version: '4.12')
-	testCompile(group: 'org.jetbrains.spek', name: 'spek', version: '0.1.194')
+	testCompile(group: 'org.jetbrains.kotlin', name: 'kotlin-test', version: '1.0.0-rc-1036')
 }

--- a/src/test/kotlin/com/zoltu/FetchTests.kt
+++ b/src/test/kotlin/com/zoltu/FetchTests.kt
@@ -2,48 +2,45 @@ package com.zoltu
 
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
-import org.jetbrains.spek.api.Spek
+import org.junit.Test
 import java.time.Duration
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
-class FetchTests : Spek() {
-	init {
-		given("primed with topic") {
-			val stubKafkaBroker = StubKafkaBroker()
-			stubKafkaBroker.addTopic("my topic")
+class FetchTests {
+	@Test
+	fun `given a primed topic - on fetch - it yields no records`() {
+		/* arrange */
+		val stubKafkaBroker = StubKafkaBroker()
+		stubKafkaBroker.addTopic("my topic")
 
-			on("fetch") {
-				val kafkaConsumer = getDefaultKafkaConsumer(stubKafkaBroker.thisBroker.port())
-				kafkaConsumer.assign(listOf(TopicPartition("my topic", 0)))
-				val consumerRecords = kafkaConsumer.poll(Duration.ofMillis(100).toMillis()).records("my topic")
+		/* act */
+		val kafkaConsumer = getDefaultKafkaConsumer(stubKafkaBroker.thisBroker.port())
+		kafkaConsumer.assign(listOf(TopicPartition("my topic", 0)))
+		val consumerRecords = kafkaConsumer.poll(Duration.ofMillis(100).toMillis()).records("my topic")
 
-				it("is not null") {
-					assertNotNull(consumerRecords)
-					assertEquals(0, consumerRecords.count())
-				}
-			}
-		}
+		/* assert */
+		assertEquals(0, consumerRecords.count())
+	}
 
-		given("primed with topic with messages") {
-			val stubKafkaBroker = StubKafkaBroker()
-			stubKafkaBroker.addTopic("my topic")
-			val kafkaProducer = getDefaultKafkaProducer(stubKafkaBroker.thisBroker.port())
-			kafkaProducer.send(ProducerRecord("my topic", "foo".toByteArray(Charsets.UTF_8)))
-			kafkaProducer.send(ProducerRecord("my topic", "bar".toByteArray(Charsets.UTF_8))).get()!!
+	@Test
+	fun `given a primed topic with produced messages - on fetch - it yields produced messages`() {
+		/* arrange */
+		val stubKafkaBroker = StubKafkaBroker()
+		stubKafkaBroker.addTopic("my topic")
+		val kafkaProducer = getDefaultKafkaProducer(stubKafkaBroker.thisBroker.port())
+		kafkaProducer.send(ProducerRecord("my topic", "foo".toByteArray(Charsets.UTF_8)))
+		kafkaProducer.send(ProducerRecord("my topic", "bar".toByteArray(Charsets.UTF_8))).get()!!
 
-			on("fetch") {
-				val kafkaConsumer = getDefaultKafkaConsumer(stubKafkaBroker.thisBroker.port())
-				kafkaConsumer.assign(listOf(TopicPartition("my topic", 0)))
-				val consumerRecords = kafkaConsumer.poll(Duration.ofMinutes(1000).toMillis()).records("my topic")
+		/* act */
+		val kafkaConsumer = getDefaultKafkaConsumer(stubKafkaBroker.thisBroker.port())
+		kafkaConsumer.assign(listOf(TopicPartition("my topic", 0)))
+		val consumerRecords = kafkaConsumer.poll(Duration.ofMinutes(1000).toMillis()).records("my topic")
 
-				it("is not null") {
-					assertNotNull(consumerRecords)
-					assertEquals(2, consumerRecords.count())
-					assertEquals("foo", consumerRecords.first().value().toString(Charsets.UTF_8))
-					assertEquals("bar", consumerRecords.last().value().toString(Charsets.UTF_8))
-				}
-			}
-		}
+		/* assert */
+		assertNotNull(consumerRecords)
+		assertEquals(2, consumerRecords.count())
+		assertEquals("foo", consumerRecords.first().value().toString(Charsets.UTF_8))
+		assertEquals("bar", consumerRecords.last().value().toString(Charsets.UTF_8))
 	}
 }

--- a/src/test/kotlin/com/zoltu/GroupManagementTests.kt
+++ b/src/test/kotlin/com/zoltu/GroupManagementTests.kt
@@ -1,49 +1,44 @@
 package com.zoltu
 
 import org.apache.kafka.clients.producer.ProducerRecord
-import org.jetbrains.spek.api.Spek
+import org.junit.Test
 import java.time.Duration
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
-class GroupManagementTests : Spek() {
-	init {
-		given("no priming") {
-			val stubKafkaBroker = StubKafkaBroker()
+class GroupManagementTests {
+	@Test
+	fun `given no primes - on commit - it yields no records`() {
+		/* arrange */
+		val stubKafkaBroker = StubKafkaBroker()
 
-			on("commit") {
-				val kafkaConsumer = getDefaultKafkaConsumer(stubKafkaBroker.thisBroker.port())
-				kafkaConsumer.subscribe(listOf("my topic"))
-				val consumerRecords = kafkaConsumer.poll(0)
+		/* act */
+		val kafkaConsumer = getDefaultKafkaConsumer(stubKafkaBroker.thisBroker.port())
+		kafkaConsumer.subscribe(listOf("my topic"))
+		val consumerRecords = kafkaConsumer.poll(0)
 
-				it("returned no records") {
-					assert(consumerRecords.isEmpty)
-				}
-			}
-		}
+		/* assert */
+		assert(consumerRecords.isEmpty)
+	}
 
-		given("primed with topic and messages produced") {
-			val stubKafkaBroker = StubKafkaBroker()
-			stubKafkaBroker.addTopic("my topic")
-			val kafkaProducer = getDefaultKafkaProducer(stubKafkaBroker.thisBroker.port())
-			kafkaProducer.send(ProducerRecord("my topic", "zip".toByteArray())).get()!!
-			kafkaProducer.send(ProducerRecord("my topic", "zap".toByteArray())).get()!!
-			kafkaProducer.send(ProducerRecord("my topic", "baz".toByteArray())).get()!!
+	@Test
+	fun `given primed topic and messages produced to it - on subscribe and poll - it returns all produced records`() {
+		/* arrange */
+		val stubKafkaBroker = StubKafkaBroker()
+		stubKafkaBroker.addTopic("my topic")
+		val kafkaProducer = getDefaultKafkaProducer(stubKafkaBroker.thisBroker.port())
+		kafkaProducer.send(ProducerRecord("my topic", "zip".toByteArray())).get()!!
+		kafkaProducer.send(ProducerRecord("my topic", "zap".toByteArray())).get()!!
+		kafkaProducer.send(ProducerRecord("my topic", "baz".toByteArray())).get()!!
 
-			on("subscribe and poll") {
-				val kafkaConsumer = getDefaultKafkaConsumer(stubKafkaBroker.thisBroker.port())
-				kafkaConsumer.subscribe(listOf("my topic"))
-				val consumerRecords = kafkaConsumer.poll(Duration.ofMinutes(1000).toMillis()).records("my topic").toList()
+		/* act */
+		val kafkaConsumer = getDefaultKafkaConsumer(stubKafkaBroker.thisBroker.port())
+		kafkaConsumer.subscribe(listOf("my topic"))
+		val consumerRecords = kafkaConsumer.poll(Duration.ofMinutes(1000).toMillis()).records("my topic").toList()
 
-				it("returns all 3 records") {
-					assertNotNull(consumerRecords)
-
-					assertEquals(3, consumerRecords.size)
-					assertEquals("zip", consumerRecords[0].value().toString(Charsets.UTF_8))
-					assertEquals("zap", consumerRecords[1].value().toString(Charsets.UTF_8))
-					assertEquals("baz", consumerRecords[2].value().toString(Charsets.UTF_8))
-				}
-			}
-		}
+		/* assert */
+		assertEquals(3, consumerRecords.size)
+		assertEquals("zip", consumerRecords[0]!!.value()!!.toString(Charsets.UTF_8))
+		assertEquals("zap", consumerRecords[1]!!.value()!!.toString(Charsets.UTF_8))
+		assertEquals("baz", consumerRecords[2]!!.value()!!.toString(Charsets.UTF_8))
 	}
 }

--- a/src/test/kotlin/com/zoltu/Playground.kt
+++ b/src/test/kotlin/com/zoltu/Playground.kt
@@ -1,15 +1,11 @@
 package com.zoltu
 
-import org.jetbrains.spek.api.Spek
+import org.junit.Test
+import kotlin.test.assertTrue
 
-class Playground: Spek() {
-	init {
-		given("arrange") {
-			on("act") {
-				it("assert") {
-
-				}
-			}
-		}
+class Playground {
+	@Test
+	fun `I wonder what this does…`() {
+		assertTrue(true)
 	}
 }

--- a/src/test/kotlin/com/zoltu/ProduceAndFetchTests.kt
+++ b/src/test/kotlin/com/zoltu/ProduceAndFetchTests.kt
@@ -2,39 +2,31 @@ package com.zoltu
 
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
-import org.jetbrains.spek.api.Spek
+import org.junit.Test
 import java.time.Duration
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
-class ProduceAndFetchTests : Spek() {
-	init {
-		given("primed with topic") {
-			val stubKafkaBroker = StubKafkaBroker()
-			stubKafkaBroker.addTopic("my topic")
+class ProduceAndFetchTests {
+	@Test
+	fun `given a primed topic - on alternating produce and fetch - each fetch returns the previously produced record`() {
+		/* arrange */
+		val stubKafkaBroker = StubKafkaBroker()
+		stubKafkaBroker.addTopic("my topic")
+		val kafkaProducer = getDefaultKafkaProducer(stubKafkaBroker.thisBroker.port())
+		val kafkaConsumer = getDefaultKafkaConsumer(stubKafkaBroker.thisBroker.port())
+		kafkaConsumer.assign(listOf(TopicPartition("my topic", 0)))
 
-			on("alternating produce and fetch") {
-				val kafkaProducer = getDefaultKafkaProducer(stubKafkaBroker.thisBroker.port())
-				val kafkaConsumer = getDefaultKafkaConsumer(stubKafkaBroker.thisBroker.port())
-				kafkaConsumer.assign(listOf(TopicPartition("my topic", 0)))
+		/* act */
+		kafkaProducer.send(ProducerRecord("my topic", "zip".toByteArray())).get()!!
+		val consumerRecords1 = kafkaConsumer.poll(Duration.ofMinutes(1000).toMillis()).records("my topic")
+		kafkaProducer.send(ProducerRecord("my topic", "zap".toByteArray())).get()!!
+		val consumerRecords2 = kafkaConsumer.poll(Duration.ofMinutes(1000).toMillis()).records("my topic")
+		kafkaProducer.send(ProducerRecord("my topic", "baz".toByteArray())).get()!!
+		val consumerRecords3 = kafkaConsumer.poll(Duration.ofMinutes(1000).toMillis()).records("my topic")
 
-				kafkaProducer.send(ProducerRecord("my topic", "zip".toByteArray())).get()!!
-				val consumerRecords1 = kafkaConsumer.poll(Duration.ofMinutes(1000).toMillis()).records("my topic")
-				kafkaProducer.send(ProducerRecord("my topic", "zap".toByteArray())).get()!!
-				val consumerRecords2 = kafkaConsumer.poll(Duration.ofMinutes(1000).toMillis()).records("my topic")
-				kafkaProducer.send(ProducerRecord("my topic", "baz".toByteArray())).get()!!
-				val consumerRecords3 = kafkaConsumer.poll(Duration.ofMinutes(1000).toMillis()).records("my topic")
-
-				it("returns one record with each iteration") {
-					assertNotNull(consumerRecords1)
-					assertNotNull(consumerRecords2)
-					assertNotNull(consumerRecords3)
-
-					assertEquals("zip", consumerRecords1.first().value().toString(Charsets.UTF_8))
-					assertEquals("zap", consumerRecords2.first().value().toString(Charsets.UTF_8))
-					assertEquals("baz", consumerRecords3.first().value().toString(Charsets.UTF_8))
-				}
-			}
-		}
+		/* assert */
+		assertEquals("zip", consumerRecords1!!.first()!!.value()!!.toString(Charsets.UTF_8))
+		assertEquals("zap", consumerRecords2!!.first()!!.value()!!.toString(Charsets.UTF_8))
+		assertEquals("baz", consumerRecords3!!.first()!!.value()!!.toString(Charsets.UTF_8))
 	}
 }

--- a/src/test/kotlin/com/zoltu/ProduceTests.kt
+++ b/src/test/kotlin/com/zoltu/ProduceTests.kt
@@ -1,54 +1,60 @@
 package com.zoltu
 
 import org.apache.kafka.clients.producer.ProducerRecord
-import org.jetbrains.spek.api.Spek
+import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
-class ProduceTests : Spek() {
-	init {
-		given("primed with topic") {
-			val stubKafkaBroker = StubKafkaBroker()
-			// we have to prime a topic or else the metadata requests will fail before any production is allowed by the client
-			stubKafkaBroker.addTopic("my topic")
+class ProduceTests {
+	@Test
+	fun `given a primed topic - on produce one nul message - it returns a successful write to the topic with partition 0 and offset 0`() {
+		/* arrange */
+		val stubKafkaBroker = StubKafkaBroker()
+		stubKafkaBroker.addTopic("my topic")
 
-			on("produce one null message") {
-				val kafkaProducer = getDefaultKafkaProducer(stubKafkaBroker.thisBroker.port())
-				val recordMetadata = kafkaProducer.send(ProducerRecord("my topic", null)).get()!!
+		/* act */
+		val kafkaProducer = getDefaultKafkaProducer(stubKafkaBroker.thisBroker.port())
+		val recordMetadata = kafkaProducer.send(ProducerRecord("my topic", null)).get()!!
 
-				it("returns a successful write to the topic, partition 0 and offset 0") {
-					assertEquals("my topic", recordMetadata.topic())
-					assertEquals(0, recordMetadata.partition())
-					assertEquals(0, recordMetadata.offset())
-				}
+		/* assert */
+		assertEquals("my topic", recordMetadata.topic())
+		assertEquals(0, recordMetadata.partition())
+		assertEquals(0, recordMetadata.offset())
+	}
 
-				it("contains the produced message as part of its produces") {
-					val producedMessages = stubKafkaBroker.getProducedMessages("my topic", 0)
-					assertEquals(1, producedMessages.size)
-					val producedMessage = producedMessages.first()
-					assertNull(producedMessage.key)
-					assertNull(producedMessage.message)
-				}
-			}
-		}
+	@Test
+	fun `given a primed topic - on produce one null message - it records the produced messages`() {
+		/* arrange */
+		val stubKafkaBroker = StubKafkaBroker()
+		stubKafkaBroker.addTopic("my topic")
 
-		given("primed with topic") {
-			val stubKafkaBroker = StubKafkaBroker()
-			// we have to prime a topic or else the metadata requests will fail before any production is allowed by the client
-			stubKafkaBroker.addTopic("my topic")
+		/* act */
+		val kafkaProducer = getDefaultKafkaProducer(stubKafkaBroker.thisBroker.port())
+		kafkaProducer.send(ProducerRecord("my topic", null)).get()!!
 
-			on("produce two string message") {
-				val kafkaProducer = getDefaultKafkaProducer(stubKafkaBroker.thisBroker.port())
-				kafkaProducer.send(ProducerRecord("my topic", "foo".toByteArray()))
-				kafkaProducer.send(ProducerRecord("my topic", "bar".toByteArray())).get()!!
+		/* assert */
+		val producedMessages = stubKafkaBroker.getProducedMessages("my topic", 0)
+		assertEquals(1, producedMessages.size)
+		val producedMessage = producedMessages.first()
+		assertNull(producedMessage.key)
+		assertNull(producedMessage.message)
+	}
 
-				it("contains the produced messages") {
-					val producedMessages = stubKafkaBroker.getProducedMessages("my topic", 0)
-					assertEquals(2, producedMessages.size)
-					assertEquals("foo", producedMessages.first().message?.toString(Charsets.UTF_8))
-					assertEquals("bar", producedMessages.last().message?.toString(Charsets.UTF_8))
-				}
-			}
-		}
+	@Test
+	fun `given a primed topic - on produce two string messages - it records both productions`() {
+		/* arrange */
+		val stubKafkaBroker = StubKafkaBroker()
+		stubKafkaBroker.addTopic("my topic")
+
+		/* act */
+		val kafkaProducer = getDefaultKafkaProducer(stubKafkaBroker.thisBroker.port())
+		kafkaProducer.send(ProducerRecord("my topic", "foo".toByteArray()))
+		kafkaProducer.send(ProducerRecord("my topic", "bar".toByteArray())).get()!!
+
+		/* assert */
+		val producedMessages = stubKafkaBroker.getProducedMessages("my topic", 0)
+		assertEquals(2, producedMessages.size)
+		assertEquals("foo", producedMessages.first().message?.toString(Charsets.UTF_8))
+		assertEquals("bar", producedMessages.last().message?.toString(Charsets.UTF_8))
 	}
 }

--- a/src/test/kotlin/com/zoltu/TopicMetadataTests.kt
+++ b/src/test/kotlin/com/zoltu/TopicMetadataTests.kt
@@ -1,127 +1,134 @@
 package com.zoltu
 
+import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.Node
 import org.apache.kafka.common.PartitionInfo
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
-import org.jetbrains.spek.api.Spek
+import org.junit.Test
 import java.time.Duration
 import kotlin.test.assertEquals
 
-class TopicMetadataTests : Spek() {
-	init {
-		given ("no priming") {
-			val stubKafkaBroker = StubKafkaBroker()
+class TopicMetadataTests {
+	@Test
+	fun `when not primed - on list topics - it should not return any topics`() {
+		/* arrange */
+		val stubKafkaBroker = StubKafkaBroker()
+		val kafkaConsumer = getDefaultKafkaConsumer(stubKafkaBroker.thisBroker.port())
 
-			on ("connect and list topics") {
-				val kafkaConsumer = getDefaultKafkaConsumer(stubKafkaBroker.thisBroker.port())
-				val topics = kafkaConsumer.listTopics()
+		/* act */
+		val topics = kafkaConsumer.listTopics()
 
-				it ("should return no topics") {
-					assert(topics.size == 0)
-				}
-			}
+		/* assert */
+		assertEquals(0, topics.size)
+	}
 
-			on("connect and list topics twice") {
-				val kafkaConsumer = getDefaultKafkaConsumer(stubKafkaBroker.thisBroker.port())
-				val topics1 = kafkaConsumer.listTopics()
-				val topics2 = kafkaConsumer.listTopics()
+	@Test
+	fun `when not primed - on list topics multiple times - it should not return any topics`() {
+		/* arrange */
+		val stubKafkaBroker = StubKafkaBroker()
+		val kafkaConsumer = getDefaultKafkaConsumer(stubKafkaBroker.thisBroker.port())
 
-				it("should return no topics on either call") {
-					assert(topics1.size == 0)
-					assert(topics2.size == 0)
-				}
-			}
+		/* act */
+		val topics1 = kafkaConsumer.listTopics()
+		val topics2 = kafkaConsumer.listTopics()
 
-			on ("request metadata for specific topic") {
-				val kafkaProducer = getDefaultKafkaProducer(stubKafkaBroker.thisBroker.port())
-				val topicMetadata = kafkaProducer.partitionsFor("my topic")!!
+		/* assert */
+		assertEquals(0, topics1.size)
+		assertEquals(0, topics2.size)
+	}
 
-				it("should return the requested topic with one partition lead by this broker") {
-					assertEquals(1, topicMetadata.size)
-					val partitionInfo = topicMetadata.single()!!
-					assertEquals("my topic", partitionInfo.topic())
-					assertEquals(0, partitionInfo.partition())
-					assertEquals(stubKafkaBroker.thisBroker.host(), partitionInfo.leader().host())
-					assertEquals(stubKafkaBroker.thisBroker.port(), partitionInfo.leader().port())
-				}
-			}
+	@Test
+	fun `when not primed - on request metadata for a specific topic - it should return the requested topic with one partition lead by this broker`() {
+		/* arrange */
+		val stubKafkaBroker = StubKafkaBroker()
+		val kafkaProducer = getDefaultKafkaProducer(stubKafkaBroker.thisBroker.port())
+
+		/* act */
+		val topicMetadata = kafkaProducer.partitionsFor("my topic")!!
+
+		/* assert */
+		assertEquals(1, topicMetadata.size)
+		val partitionInfo = topicMetadata.single()!!
+		assertEquals("my topic", partitionInfo.topic())
+		assertEquals(0, partitionInfo.partition())
+		assertEquals(stubKafkaBroker.thisBroker.host(), partitionInfo.leader().host())
+		assertEquals(stubKafkaBroker.thisBroker.port(), partitionInfo.leader().port())
+	}
+
+	@Test
+	fun `when primed with one topic - on list topics - it should return the primed topic`() {
+		/* arrange */
+		val stubKafkaBroker = StubKafkaBroker()
+		stubKafkaBroker.addTopic("my topic")
+		val kafkaConsumer = getDefaultKafkaConsumer(stubKafkaBroker.thisBroker.port())
+
+		/* act */
+		val topics = kafkaConsumer.listTopics()
+
+		/* assert */
+		assertEquals("my topic", topics.entries.single().key)
+	}
+
+	@Test
+	fun `when primed with one topic - on reset then list topics - it should not return any topics`() {
+		/* arrange */
+		val stubKafkaBroker = StubKafkaBroker()
+		stubKafkaBroker.addTopic("my topic")
+		val kafkaConsumer = getDefaultKafkaConsumer(stubKafkaBroker.thisBroker.port())
+
+		/* act */
+		stubKafkaBroker.reset()
+		val topics = kafkaConsumer.listTopics()
+
+		/* assert */
+		assertEquals(0, topics.size)
+	}
+
+	@Test
+	fun `when primed with one topic lead by another broker - on list topics - it shoud get the topic with the other broker as leader`() {
+		/* arrange */
+		val stubKafkaBroker = StubKafkaBroker()
+		val otherBroker = Node(1, "somewhere", 1234)
+		stubKafkaBroker.addBroker(otherBroker)
+		stubKafkaBroker.addPartition(PartitionInfo("my topic", 1, otherBroker, emptyArray(), emptyArray()))
+		val kafkaConsumer = getDefaultKafkaConsumer(stubKafkaBroker.thisBroker.port())
+
+		/* act */
+		val topics = kafkaConsumer.listTopics()
+
+		/* assert */
+		assertEquals(1, topics.size)
+		val topic = topics.entries.single()
+		assertEquals("my topic", topic.key)
+		assertEquals(1, topic.value.size)
+		val partition = topic.value.single()
+		val leader = partition.leader()
+		assertEquals(1, leader.id())
+		assertEquals("somewhere", leader.host())
+		assertEquals(1234, leader.port())
+	}
+
+	@Test
+	fun `when primed with a slow responding broker but a secondary broker is fast - on list topics - it should get the topics from the fast broker`() {
+		/* arrange */
+		val stubKafkaBrokerSlow = StubKafkaBroker()
+		stubKafkaBrokerSlow.addTopic("my topic slow")
+		val defaultMetadataRequestHandler = stubKafkaBrokerSlow.metadataRequestHandler
+		stubKafkaBrokerSlow.metadataRequestHandler = { requestHeader, metadataRequest ->
+			Thread.sleep(Duration.ofSeconds(2).toMillis())
+			defaultMetadataRequestHandler(requestHeader, metadataRequest)
 		}
+		val stubKafkaBrokerFast = StubKafkaBroker()
+		stubKafkaBrokerFast.addTopic("my topic fast")
+		val consumerProperties = getDefaultConsumerProperties(0)
+		consumerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:${stubKafkaBrokerSlow.thisBroker.port()};localhost:${stubKafkaBrokerFast.thisBroker.port()}")
+		val kafkaConsumer = KafkaConsumer<ByteArray, ByteArray>(consumerProperties, ByteArrayDeserializer(), ByteArrayDeserializer())
 
-		given("primed with one topic") {
-			val stubKafkaBroker = StubKafkaBroker()
-			stubKafkaBroker.addTopic("my topic")
+		/* act */
+		val topics = kafkaConsumer.listTopics()
 
-			on("list topics") {
-				val kafkaConsumer = getDefaultKafkaConsumer(stubKafkaBroker.thisBroker.port())
-				val topics = kafkaConsumer.listTopics()
-
-				it("should get the topic") {
-					assertEquals("my topic", topics.entries.single().key)
-				}
-			}
-		}
-
-		given("primed with one topic") {
-			val stubKafkaBroker = StubKafkaBroker()
-			stubKafkaBroker.addTopic("my topic")
-
-			on("reset") {
-				stubKafkaBroker.reset()
-
-				it("forgets the topic") {
-					val kafkaConsumer = getDefaultKafkaConsumer(stubKafkaBroker.thisBroker.port())
-					val topics = kafkaConsumer.listTopics()
-					assertEquals(0, topics.size)
-				}
-			}
-		}
-
-		given("a down broker primed and a topic primed with the down broker as primary") {
-			val stubKafkaBroker = StubKafkaBroker()
-			val downBroker = Node(1, "somewhere", 1234)
-			stubKafkaBroker.addBroker(downBroker)
-			stubKafkaBroker.addPartition(PartitionInfo("my topic", 1, downBroker, emptyArray(), emptyArray()))
-
-			on("list topics") {
-				val kafkaConsumer = getDefaultKafkaConsumer(stubKafkaBroker.thisBroker.port())
-				val topics = kafkaConsumer.listTopics()
-
-				it("should get the topic with the down broker as leader") {
-					assertEquals(1, topics.size)
-					val topic = topics.entries.single()
-					assertEquals("my topic", topic.key)
-					assertEquals(1, topic.value.size)
-					val partition = topic.value.single()
-					val leader = partition.leader()
-					assertEquals(1, leader.id())
-					assertEquals("somewhere", leader.host())
-					assertEquals(1234, leader.port())
-				}
-			}
-		}
-
-		given("a delayed response to MetadataRequest and a stub broker with a fast response") {
-			val stubKafkaBrokerSlow = StubKafkaBroker()
-			val stubKafkaBrokerFast = StubKafkaBroker()
-			stubKafkaBrokerSlow.addTopic("my topic")
-			stubKafkaBrokerFast.addTopic("my topic")
-			val defaultMetadataRequestHandler = stubKafkaBrokerSlow.metadataRequestHandler
-			stubKafkaBrokerSlow.metadataRequestHandler = { requestHeader, metadataRequest ->
-				Thread.sleep(Duration.ofMillis(1100).toMillis())
-				defaultMetadataRequestHandler(requestHeader, metadataRequest)
-			}
-
-			on("list topic") {
-				val properties = getDefaultConsumerProperties(0)
-				properties.put("bootstrap.servers", "localhost:${stubKafkaBrokerSlow.thisBroker.port()};localhost:${stubKafkaBrokerFast.thisBroker.port()}")
-				val kafkaConsumer = KafkaConsumer<ByteArray, ByteArray>(properties, ByteArrayDeserializer(), ByteArrayDeserializer())
-				val topics = kafkaConsumer.listTopics()
-
-				it("should timeout") {
-					assertEquals("my topic", topics.entries.single().key)
-				}
-			}
-		}
+		/* assert */
+		assertEquals("my topic fast", topics.entries.single().key)
 	}
 }


### PR DESCRIPTION
Spek is cool, but IntelliJ's integration with it is pretty weak.  The primary problem is that you can't run individual subsets of tests inside IntelliJ which can make debugging failing tests quite painful.

Also, in spek tests the `given` is run once for all `on`s underneath it and the `on` is run once for all `it`s underneath it.  This makes it easy to have tests that influence each other causing unexpected behavior.
